### PR TITLE
fix rounding error causing CPU hog

### DIFF
--- a/mysql_statsd/thread_mysql.py
+++ b/mysql_statsd/thread_mysql.py
@@ -41,7 +41,7 @@ class ThreadMySQL(ThreadBase):
                 }
                 self.check_lastrun[stats_type] = (time.time()*1000)
 
-        self.sleep_interval = int(config_dict.get('mysql').get('sleep_interval', 500))/1000
+        self.sleep_interval = int(config_dict.get('mysql').get('sleep_interval', 500))/1000.0
 
         #Which metrics do we allow to be sent to the backend?
         self.metrics = config_dict.get('metrics')


### PR DESCRIPTION
time.sleep accepts a floating point variable to indicate a more precise sleep times. Without the fix the default sleep time would be rounded down to 0.
