### PR TITLE
Support for SHOW SLAVE STATUS via a ColumnsPreprocessor

### DIFF
--- a/mysql_statsd/preprocessors/columns_preprocessor.py
+++ b/mysql_statsd/preprocessors/columns_preprocessor.py
@@ -6,7 +6,7 @@ class ColumnsPreprocessor(Preprocessor):
     def __init__(self, *args, **kwargs):
         super(ColumnsPreprocessor, self).__init__(*args, **kwargs)
 
-    def process(self, column_names, rows):
+    def process(self, rows, column_names):
         if not rows:
             return []
         return zip(column_names, rows[0])

--- a/mysql_statsd/preprocessors/innodb_preprocessor.py
+++ b/mysql_statsd/preprocessors/innodb_preprocessor.py
@@ -33,7 +33,7 @@ class InnoDBPreprocessor(Preprocessor):
         self.txn_seen = 0
         self.prev_line = ''
 
-    def process(self, column_names, rows):
+    def process(self, rows):
         self.clear_variables()
         for row in rows:
             innoblob = row[2].replace(',', '').replace(';', '').replace('/s', '').split('\n')

--- a/mysql_statsd/preprocessors/mysql_preprocessor.py
+++ b/mysql_statsd/preprocessors/mysql_preprocessor.py
@@ -5,5 +5,5 @@ class MysqlPreprocessor(Preprocessor):
     def __init__(self, *args, **kwargs):
         super(MysqlPreprocessor, self).__init__(*args, **kwargs)
 
-    def process(self, column_names, rows):
+    def process(self, rows):
         return list(rows)

--- a/mysql_statsd/thread_mysql.py
+++ b/mysql_statsd/thread_mysql.py
@@ -106,13 +106,16 @@ class ThreadMySQL(ThreadBase):
         Return rows when type not innodb.
         This is done to make it transparent for furture transformation types
         """
+        extra_args = ()
+
         executing_class = self.processor_class_mysql
         if check_type == 'innodb':
             executing_class = self.processor_class_inno
         if check_type == 'slave':
             executing_class = self.processor_class_columns
+            extra_args = (column_names,)
 
-        return executing_class.process(column_names, rows)
+        return executing_class.process(rows, *extra_args)
 
     def reconnect(self):
         if self.die_on_max_reconnect and self.reconnect_attempt >= self.max_reconnect:


### PR DESCRIPTION
Ability to capture `SHOW SLAVE STATUS` output (`Seconds_Behind_Master` et al.). This will also work for other queries that return a single row, and the variables are the actual columns.
