### PR TITLE
Allow max_reconnect to be configurable, allow infinite retries

### DIFF
--- a/docs/mysql-statsd.conf
+++ b/docs/mysql-statsd.conf
@@ -9,6 +9,8 @@ prefix = mysql
 include_hostname = true
 
 [mysql]
+; specify 0 for infinite connection retries
+max_reconnect = 30
 host = localhost
 username = root
 password = 


### PR DESCRIPTION
Right now, mysql_statsd hardcodes 30 connection retries to mysql with a 5s delay. Allow the number of connection retries to be configurable, including 0 if you want mysql_statsd to keep retrying ad infinitum.

This also includes a change to use loops for retries rather than recursion (to support infinite retries).