### PR TITLE
fix exception

### DIFF
--- a/mysql_statsd/preprocessors/innodb_preprocessor.py
+++ b/mysql_statsd/preprocessors/innodb_preprocessor.py
@@ -27,7 +27,7 @@ class InnoDBPreprocessor(Preprocessor):
             if lo is None:
                 lo = 0
 
-        return (hi * 4294967296) + lo
+        return (int(hi) * 4294967296) + int(lo)
 
     def clear_variables(self):
         self.tmp_stats = {}


### PR DESCRIPTION
Traceback (most recent call last):
      File "/usr/local/lib/python2.7/threading.py", line 810, in
      __bootstrap_inner
          self.run()
        File
      "/mnt/alidata1/data/code/mysql-statsd/mysql_statsd/thread_mysql.py",
      line 175, in run
          self._run()
        File
      "/mnt/alidata1/data/code/mysql-statsd/mysql_statsd/thread_mysql.py",
      line 112, in _run
          rows = self._preprocess(check_type, column_names,
                                  cursor.fetchall())
        File
      "/mnt/alidata1/data/code/mysql-statsd/mysql_statsd/thread_mysql.py",
      line 148, in _preprocess
          return executing_class.process(rows, *extra_args)
        File
      "/mnt/alidata1/data/code/mysql-statsd/mysql_statsd/preprocessors/innodb_preprocessor.py",
      line 76, in process
          self.process_line(line)
        File
      "/mnt/alidata1/data/code/mysql-statsd/mysql_statsd/preprocessors/innodb_preprocessor.py",
      line 209, in process_line
          self.tmp_stats['innodb_transactions'] =
      self.make_bigint(innorow[3], innorow[4])
        File
      "/mnt/alidata1/data/code/mysql-statsd/mysql_statsd/preprocessors/innodb_preprocessor.py",
      line 36, in make_bigint
          raise e
      MemoryError
